### PR TITLE
Fix typo in function name: keyOparation -> keyOperation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,114 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# IDE settings
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/Tetris_module.py
+++ b/Tetris_module.py
@@ -84,7 +84,7 @@ def create_grid(locked_pos):
     return grid
 
 
-def keyOparation(game_running, key, grid, current_mino):
+def keyOperation(game_running, key, grid, current_mino):
     if key == pygame.K_ESCAPE:
         game_running = False
         pygame.display.quit()

--- a/tetris_pygame.py
+++ b/tetris_pygame.py
@@ -4,7 +4,7 @@ import random
 import datetime
 import copy
 from Tetris_module import draw_gridlines,draw_window,clear_rows,get_mino_positions
-from Tetris_module import valid_space,lock_mino,create_grid,keyOparation,check_lost
+from Tetris_module import valid_space,lock_mino,create_grid,keyOperation,check_lost
 from Tetris_module import draw_next_shape
 from constants import (
     S_WIDTH, S_HEIGHT, PLAY_WIDTH, PLAY_HEIGHT, BLOCK_SIZE,
@@ -51,7 +51,7 @@ def main():
                 game_running = False
                 pygame.display.quit()
             if event.type == pygame.KEYDOWN:  # ESC以外のキー入力（矢印キーとシフトキー）
-                game_running, current_mino = keyOparation(game_running, event.key, grid, current_mino)
+                game_running, current_mino = keyOperation(game_running, event.key, grid, current_mino)
 
         current_second = (datetime.datetime.now()).second  # 現在の秒数取得
         if last_fall_second != current_second:  # 1秒経過した場合


### PR DESCRIPTION
## Summary
- `keyOparation`を`keyOperation`にスペルミス修正
- `.gitignore`を追加してPythonキャッシュファイルを除外

## Changes
- `Tetris_module.py`: 関数定義を修正
- `tetris_pygame.py`: 関数呼び出しを修正
- `.gitignore`: 新規作成（Pythonの標準的な除外パターン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)