### PR TITLE
Refactor: Improve time management with pygame.time

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -29,6 +29,10 @@ MINO_GRID_SIZE = 5
 MINO_INNER_GRID = 4  # ミノの実際の描画サイズ（5x5グリッドの中の4x4）
 SCORE_PER_LINE = 100
 
+# Time control
+FALL_INTERVAL = 1000  # ミノの自動落下間隔（ミリ秒）
+FPS = 60  # フレームレート
+
 # Mino starting position
 MINO_START_X = 3
 MINO_START_Y = 0

--- a/tetris_pygame.py
+++ b/tetris_pygame.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import pygame
 import random
-import datetime
 import copy
 from Tetris_module import draw_gridlines,draw_window,clear_rows,get_mino_positions
 from Tetris_module import valid_space,lock_mino,create_grid,keyOperation,check_lost
 from Tetris_module import draw_next_shape
 from constants import (
     S_WIDTH, S_HEIGHT, PLAY_WIDTH, PLAY_HEIGHT, BLOCK_SIZE,
-    GRID_WIDTH, GRID_HEIGHT, MINO_START_X, MINO_START_Y, MINO_GRID_SIZE
+    GRID_WIDTH, GRID_HEIGHT, MINO_START_X, MINO_START_Y, MINO_GRID_SIZE,
+    FALL_INTERVAL, FPS
 )
 from shapes import SHAPES, SHAPE_COLORS
 
@@ -40,9 +40,11 @@ def main():
 
     score = 0
     game_running = True  # ゲームループを走らせるためのフラグ
-    last_fall_second = (datetime.datetime.now()).second  # 最後に落下した時刻（秒）
+    clock = pygame.time.Clock()  # フレームレート制御用
+    last_fall_time = pygame.time.get_ticks()  # 最後に落下した時刻（ミリ秒）
     #ループ
     while game_running:
+        clock.tick(FPS)  # フレームレートを制限
         #現在gridに固定ミノ座標を登録
         grid = create_grid(locked_positions)
 
@@ -53,9 +55,9 @@ def main():
             if event.type == pygame.KEYDOWN:  # ESC以外のキー入力（矢印キーとシフトキー）
                 game_running, current_mino = keyOperation(game_running, event.key, grid, current_mino)
 
-        current_second = (datetime.datetime.now()).second  # 現在の秒数取得
-        if last_fall_second != current_second:  # 1秒経過した場合
-            last_fall_second = current_second
+        current_time = pygame.time.get_ticks()  # 現在時刻取得（ミリ秒）
+        if current_time - last_fall_time >= FALL_INTERVAL:  # 指定間隔経過した場合
+            last_fall_time = current_time
             current_mino.y += 1  # ミノを1マス落下
             if not valid_space(grid, current_mino):  # 当たり判定で重なってしまう場合
                 current_mino.y -= 1  # ミノを重ならない状態に戻す


### PR DESCRIPTION
## Summary
`datetime`ベースの時間管理を`pygame.time`に置き換えて、より正確で信頼性の高いゲームタイミングを実現しました。

## 背景：なぜこの変更が必要だったのか

### 以前の実装の問題点
`datetime.now().second`（0〜59の秒の値）を使用していたため、以下の問題がありました：

1. **不正確な時間測定**
   - 59秒900ms → 0秒100ms の場合、実際は200msしか経過していないのに「1秒経過」と判定される
   - 30秒100ms → 31秒900ms の場合、実際は1.8秒経過しているのに1回しか落下しない

2. **Pygameとの不整合**
   - Pygameの時間管理システムと別系統
   - ゲーム内の他の時間制御と統一できない

## 変更内容

### constants.py
- `FALL_INTERVAL = 1000`（ミリ秒）を追加：ミノの自動落下間隔
- `FPS = 60` を追加：フレームレート制限

### tetris_pygame.py
- `import datetime` を削除
- `pygame.time.Clock()` でフレームレート制御
- `pygame.time.get_ticks()` でミリ秒単位の経過時間を測定
- 秒の比較から経過時間の差分チェックに変更

## メリット

### 1. 正確性
- ミリ秒単位で正確に1000ms（1秒）ごとに落下
- 秒の境界での誤動作がなくなる

### 2. パフォーマンス
- `clock.tick(60)` でフレームレートを60FPSに制限
- CPU使用率を削減

### 3. 拡張性
- 落下速度を定数で簡単に変更可能
- 将来的な機能追加が容易：
  ```python
  # レベルに応じて速度変更
  fall_interval = max(100, 1000 - level * 50)
  
  # ソフトドロップ機能
  if soft_drop:
      fall_interval = 50
  ```

### 4. Pygameとの一貫性
- Pygame標準の時間管理システムを使用
- 他のゲームロジックと統一された時間制御

## テスト確認項目
- [ ] ミノが正確に1秒ごとに1マス落下する
- [ ] 秒の境界（59秒→0秒）で正常に動作する
- [ ] フレームレートが適切に制限されている（CPU使用率の確認）
- [ ] ゲーム全体が滑らかに動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)